### PR TITLE
Added support for a host of paper-input attributes

### DIFF
--- a/paper-input-autocomplete.html
+++ b/paper-input-autocomplete.html
@@ -70,7 +70,12 @@ Example:
 
   <template>
     <div class="input-wrapper">
-      <paper-input id="input" label="{{label}}" no-label-float on-keyup="_handleSuggestions"></paper-input>
+      <paper-input id="input" label="{{label}}" on-keyup="_handleSuggestions" disabled="{{disabled}}" invalid="{{invalid}}"
+                   prevent-invalid-input="{{preventInvalidInput}}" allowedpattern="{{allowedPattern}}" type="{{type}}" list="{{list}}"
+                   pattern="{{pattern}}" required="{{required}}" maxlength="{{maxlength}}" error-message="{{errorMessage}}" char-counter="{{charCounter}}"
+                   auto-validate="{{autoValidate}}" validator="{{validator}}" autocomplete="{{autocomplete}}" autofocus="{{autofocus}}"
+                   inputmode="{{inputmode}}" minlength="{{minlength}}" name="{{name}}" placeholder="{{placeholder}}" readonly="{{readonly}}"
+                   size="{{size}}" _aria-described-by="{{_ariaDescribedBy}}" value="{{inputValue}}" no-label-float="{{noLabelFloat}}" always-float-label="{{alwaysFloatLabel}}"></paper-input>
       <paper-icon-button id="clear" icon="clear" on-click="_clear"></paper-icon-button>
     </div>
     <paper-material elevation="1" id="suggestionsWrapper">
@@ -116,6 +121,14 @@ Example:
       },
 
       /**
+        * `inputValue` Current value of the input-paper element
+        */
+      inputValue: {
+          type: String,
+          notify: true
+      },
+
+      /**
        * `suggestionsInOverlay` Display the suggestions in an overlay above the next elements
        */
       suggestionsInOverlay: Boolean,
@@ -123,7 +136,203 @@ Example:
       /**
        * `_suggestions` Array with the actual suggestions to display
        */
-      _suggestions: Array
+      _suggestions: Array,
+
+
+
+        /**
+         * Set to true to disable this input. Bind this to both the `<paper-input-container>`'s
+         * and the input's `disabled` property.
+         */
+      disabled: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Returns true if the value is invalid. Bind this to both the `<paper-input-container>`'s
+         * and the input's `invalid` property.
+         */
+      invalid: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Set to true to prevent the user from entering invalid input. Bind this to the
+         * `<input is="iron-input">`'s `preventInvalidInput` property.
+         */
+      preventInvalidInput: {
+          type: Boolean
+      },
+
+        /**
+         * Set this to specify the pattern allowed by `preventInvalidInput`. Bind this to the
+         * `<input is="iron-input">`'s `allowedPattern` property.
+         */
+      allowedPattern: {
+          type: String
+      },
+
+        /**
+         * The type of the input. The supported types are `text`, `number` and `password`. Bind this
+         * to the `<input is="iron-input">`'s `type` property.
+         */
+      type: {
+          type: String
+      },
+
+        /**
+         * The datalist of the input (if any). This should match the id of an existing <datalist>. Bind this
+         * to the `<input is="iron-input">`'s `list` property.
+         */
+      list: {
+          type: String
+      },
+
+        /**
+         * A pattern to validate the `input` with. Bind this to the `<input is="iron-input">`'s
+         * `pattern` property.
+         */
+      pattern: {
+          type: String
+      },
+
+        /**
+         * Set to true to mark the input as required. Bind this to the `<input is="iron-input">`'s
+         * `required` property.
+         */
+      required: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * The maximum length of the input value. Bind this to the `<input is="iron-input">`'s
+         * `maxlength` property.
+         */
+      maxlength: {
+          type: Number
+      },
+
+        /**
+         * The error message to display when the input is invalid. Bind this to the
+         * `<paper-input-error>`'s content, if using.
+         */
+      errorMessage: {
+          type: String
+      },
+
+        /**
+         * Set to true to show a character counter.
+         */
+      charCounter: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Set to true to disable the floating label. Bind this to the `<paper-input-container>`'s
+         * `noLabelFloat` property.
+         */
+      noLabelFloat: {
+          type: Boolean,
+          value: true,
+          notify: true,
+      },
+
+        /**
+         * Set to true to always float the label. Bind this to the `<paper-input-container>`'s
+         * `alwaysFloatLabel` property.
+         */
+      alwaysFloatLabel: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Set to true to auto-validate the input value. Bind this to the `<paper-input-container>`'s
+         * `autoValidate` property.
+         */
+      autoValidate: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Name of the validator to use. Bind this to the `<input is="iron-input">`'s `validator`
+         * property.
+         */
+      validator: {
+          type: String
+      },
+
+        // HTMLInputElement attributes for binding if needed
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `autocomplete` property.
+         */
+      autocomplete: {
+          type: String,
+          value: 'off'
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `autofocus` property.
+         */
+      autofocus: {
+          type: Boolean
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `inputmode` property.
+         */
+      inputmode: {
+          type: String
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `minlength` property.
+         */
+      minlength: {
+          type: Number
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `name` property.
+         */
+      name: {
+          type: String
+      },
+
+        /**
+         * A placeholder string in addition to the label. If this is set, the label will always float.
+         */
+      placeholder: {
+          type: String,
+          // need to set a default so _computeAlwaysFloatLabel is run
+          value: ''
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `readonly` property.
+         */
+      readonly: {
+          type: Boolean,
+          value: false
+      },
+
+        /**
+         * Bind this to the `<input is="iron-input">`'s `size` property.
+         */
+      size: {
+          type: Number
+      },
+
+      _ariaDescribedBy: {
+          type: String,
+          value: ''
+      }
 
     },
 
@@ -135,7 +344,7 @@ Example:
       // are not.
       //
       // This is the point where you should make modifications to the DOM (when
-      // necessary), or kick off any processes the element wants to perform.
+        // necessary), or kick off any processes the element wants to perform.
     },
 
     attached: function() {
@@ -144,7 +353,7 @@ Example:
       //
       // This is a good place to perform any work related to your element's
       // visual state or active behavior (measuring sizes, beginning animations,
-      // loading resources, etc).
+        // loading resources, etc).
     },
 
     detached: function() {
@@ -179,7 +388,8 @@ Example:
      * @param {string} event fired
      */
     _handleSuggestions : function(event) {
-      var value = event.target.value;
+        var value = event.target.value;
+        console.log('acval = ' + value);
 
       if(value && value.length > 0){
         value = value.toLowerCase();


### PR DESCRIPTION
Added support for a host of paper-input attributes; also added binding to the current text value of the input, even if it's not a valid selection (for validation).  Tried to keep existing attributes with existing defaults.

Thanks for your work on this.
